### PR TITLE
chore: disable a rule of "@typescript-eslint/explicit-module-boundary-types"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     "prettier/@typescript-eslint",
   ],
   rules: {
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "react/react-in-jsx-scope": "off",
   },
 };


### PR DESCRIPTION
ルールの説明はこちら
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md

型アノテーションを律儀にやるのであれば有効でも良いのですが、既存のコーディングスタイルと記述量が増える点を考慮すると、offでよいかなあと思いました