### PR TITLE
fix: format stepのときdetached HEADでcommitできない

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
       - id: yarn_cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2


### PR DESCRIPTION
actions/checkout@v2でrefのinputを設定することで、HEADの上でciを動かせるようですね

githubコンテキストの github.head_ref でHEADを指定できるようです https://docs.github.com/ja/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88

参考: https://qiita.com/Ouvill/items/7b6df0e9b981093b330f#pull-request-%E3%82%92%E3%82%82%E3%82%89%E3%81%A3%E3%81%9F%E3%81%A8%E3%81%8D%E3%81%AB-pr-%E3%83%96%E3%83%A9%E3%83%B3%E3%83%81%E3%82%92%E6%95%B4%E5%BD%A2